### PR TITLE
Revert "Update ghcr.io/netbox-community/netbox Docker tag to v3.5.0"

### DIFF
--- a/modules/netbox-heroku/config/Dockerfile
+++ b/modules/netbox-heroku/config/Dockerfile
@@ -1,5 +1,5 @@
 # pinned to specific release
-ARG NETBOX_VERSION=v3.5.0
+ARG NETBOX_VERSION=v3.4.8
 FROM ghcr.io/netbox-community/netbox:${NETBOX_VERSION} AS base
 
 COPY requirements.txt /opt/netbox-heroku/requirements.txt


### PR DESCRIPTION
Reverts ffddorf/netbox-heroku-docker#65

Blocked on https://github.com/ffddorf/netbox-heroku-docker/issues/60