### PR TITLE
Revert "Update ghcr.io/netbox-community/netbox Docker tag to v3.5.1"

### DIFF
--- a/modules/netbox-heroku/config/Dockerfile
+++ b/modules/netbox-heroku/config/Dockerfile
@@ -1,5 +1,5 @@
 # pinned to specific release
-ARG NETBOX_VERSION=v3.5.1
+ARG NETBOX_VERSION=v3.4.10
 FROM ghcr.io/netbox-community/netbox:${NETBOX_VERSION} AS base
 
 COPY requirements.txt /opt/netbox-heroku/requirements.txt

--- a/modules/netbox-heroku/config/requirements.txt
+++ b/modules/netbox-heroku/config/requirements.txt
@@ -1,6 +1,7 @@
-beautifulsoup4==4.12.2
+beautifulsoup4==4.11.2
 dj-database-url==2.0.0
 google==3.0.0
-netbox-secrets==1.8.1
+importlib==1.0.4
+netbox-secrets==1.7.6
 pycryptodome==3.17
-soupsieve==2.4.1
+soupsieve==2.4


### PR DESCRIPTION
Reverts ffddorf/netbox-heroku-docker#67

Secret decryption broke, upstream issue: https://github.com/Onemind-Services-LLC/netbox-secrets/issues/60